### PR TITLE
Fix loop_timer_ cb class name

### DIFF
--- a/resource/patternSrc.cpp
+++ b/resource/patternSrc.cpp
@@ -27,7 +27,7 @@ INITIAL_ITERATION
 
   loop_timer_ = create_wall_timer(
     std::chrono::duration<double, std::ratio<1>>(1.0 / frequency),
-    std::bind(&TestHFSM::tick, this));
+    std::bind(&ID::tick, this));
 
   state_pub_->on_activate();
   return CascadeLifecycleNode::on_activate(previous_state);


### PR DESCRIPTION
Hi @fmrico !
This PR fixes an HFSM generation error. The loop_timer_ was generated using the callback TestHFSM instead of ID.
Regards!